### PR TITLE
Pps with modulations dev

### DIFF
--- a/lib/include/iCub/periPersonalSpace/taxelPWE.h
+++ b/lib/include/iCub/periPersonalSpace/taxelPWE.h
@@ -1,8 +1,7 @@
 /**
  * Copyright (C) 2013 RobotCub Consortium, European Commission FP6 Project IST-004370
- * Author: Alessandro Roncone
- * email:  alessandro.roncone@iit.it
- * website: www.robotcub.org
+ * Author: Alessandro Roncone, Matej Hoffmann
+ * email:  alessandro.roncone@yale.edu, matej.hoffmann@iit.it
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.
@@ -23,7 +22,7 @@
  *
  * Utilities used throughout the modules and libraries.
  *
- * \author Alessandro Roncone
+ * \author Alessandro Roncone, Matej Hoffmann
  *
  * Date: first release 30/10/2013
  *
@@ -42,9 +41,10 @@ class TaxelPWE : public iCub::skinDynLib::Taxel
 {
   public:
     double    Resp;                 // taxels' activation level <0,1>
-    double RFangle;                 // angle of the receptive field [rad]
+    double RFangle;                 // angle of the receptive field [rad] - from the taxel normal
+    //the effective angle is thus double that 
 
-    IncomingEvent4TaxelPWE Evnt;    //
+    IncomingEvent4TaxelPWE Evnt;    // //stimuli/events nearing the taxel in the taxel frame of reference
     parzenWindowEstimator *pwe;     //
 
     /**

--- a/modules/visuoTactileRF/vtRFThread.cpp
+++ b/modules/visuoTactileRF/vtRFThread.cpp
@@ -103,7 +103,7 @@ bool vtRFThread::threadInit()
         
         stress = 0.0;
 
-    /**************************/
+    /****open right arm interfaces (if they are needed) **********************/
         if (rf->check("rightHand") || rf->check("rightForeArm") ||
            (!rf->check("rightHand") && !rf->check("rightForeArm") && !rf->check("leftHand") && !rf->check("leftForeArm")))
         {
@@ -133,7 +133,7 @@ bool vtRFThread::threadInit()
             encsR = new yarp::sig::Vector(jntsR,0.0);
         }
 
-    /**************************/
+    /**********open left arm interfaces (if they are needed) ****************/
         if (rf->check("leftHand") || rf->check("leftForeArm") ||
            (!rf->check("rightHand") && !rf->check("rightForeArm") && !rf->check("leftHand") && !rf->check("leftForeArm")))
         {
@@ -1252,7 +1252,7 @@ bool vtRFThread::setTaxelPosesFromFile(const string filePath, skinPartPWE &sP)
         else if (sP.name == SkinPart_s[SKIN_RIGHT_HAND])
         { //right hand has different taxel nr.s than left hand 
             // if((i==101) || (i==103) || (i==118) || (i==137)) // || (i==124)) remove one taxel
-            if((i==101) || (i==103) || (i==118) || (i==137)) // || (i==124)) remove one taxel
+            if((i==101) || (i==103) || (i==118) || (i==137) || (i==124)) 
             {
                 sP.size++;
                 if (modality=="1D")

--- a/modules/visuoTactileRF/vtRFThread.cpp
+++ b/modules/visuoTactileRF/vtRFThread.cpp
@@ -11,7 +11,6 @@
 #define SKIN_THRES	        7 // Threshold with which a contact is detected
 #define RESP_GAIN_FOR_SKINGUI 100 //To amplify PPS activations from <0,1> to <0,100>
 #define PPS_AGGREG_ACT_THRESHOLD 0.2 //Threshold for aggregated events per skin part
-#define NR_ARM_JOINTS 7
 
 IncomingEvent eventFromBottle(const Bottle &b)
 {
@@ -137,7 +136,9 @@ bool vtRFThread::threadInit()
             }
             iencsR->getAxes(&jntsR);
             encsR = new yarp::sig::Vector(jntsR,0.0); //should be 16 - arm + fingers
-            qR.resize(NR_ARM_JOINTS,0.0); //current values of arm joints (should be 7)
+            jntsAR = 7; //nr. arm joints only - without fingers
+            qR.resize(jntsAR,0.0); //current values of arm joints (should be 7)
+            
         }
 
     /********** Open left arm interfaces (if they are needed) ****************/
@@ -171,7 +172,9 @@ bool vtRFThread::threadInit()
             }
             iencsL->getAxes(&jntsL);
             encsL = new yarp::sig::Vector(jntsL,0.0); //should be 16 - arm + fingers
-            qL.resize(NR_ARM_JOINTS,0.0); //current values of arm joints (should be 7)
+            jntsAL = 7; //nr. arm joints only - without fingers
+            qL.resize(jntsAL,0.0); //current values of arm joints (should be 7)
+            
         }
 
     /**************************/
@@ -837,8 +840,8 @@ bool vtRFThread::trainTaxels(const std::vector<unsigned int> IDv, const int IDx)
 
 bool vtRFThread::readEncodersAndUpdateArmChains()
 {    
-   Vector q1(jntsT+NR_ARM_JOINTS,0.0);
-   Vector q2(jntsT+NR_ARM_JOINTS,0.0);
+   Vector q1(jntsT+jntsAR,0.0);
+   Vector q2(jntsT+jntsAL,0.0);
    iencsT->getEncoders(encsT->data());
    qT[0]=(*encsT)[2]; //reshuffling from motor to iKin order (yaw, roll, pitch)
    qT[1]=(*encsT)[1];
@@ -848,7 +851,7 @@ bool vtRFThread::readEncodersAndUpdateArmChains()
         (!rf->check("rightHand") && !rf->check("rightForeArm") && !rf->check("leftHand") && !rf->check("leftForeArm")))
    {
         iencsR->getEncoders(encsR->data());
-        qR=encsR->subVector(0,NR_ARM_JOINTS-1);
+        qR=encsR->subVector(0,jntsAR-1);
         q1.setSubvector(0,qT);
         q1.setSubvector(jntsT,qR);
         armR -> setAng(q1*CTRL_DEG2RAD);
@@ -857,7 +860,7 @@ bool vtRFThread::readEncodersAndUpdateArmChains()
            (!rf->check("rightHand") && !rf->check("rightForeArm") && !rf->check("leftHand") && !rf->check("leftForeArm")))
    {
         iencsL->getEncoders(encsL->data());
-        qL=encsL->subVector(0,NR_ARM_JOINTS-1);
+        qL=encsL->subVector(0,jntsAL-1);
         q2.setSubvector(0,qT);
         q2.setSubvector(jntsT,qL);
         armL -> setAng(q2*CTRL_DEG2RAD);

--- a/modules/visuoTactileRF/vtRFThread.cpp
+++ b/modules/visuoTactileRF/vtRFThread.cpp
@@ -12,7 +12,6 @@
 #define RESP_GAIN_FOR_SKINGUI 100 //To amplify PPS activations from <0,1> to <0,100>
 #define PPS_AGGREG_ACT_THRESHOLD 0.2 //Threshold for aggregated events per skin part
 #define NR_ARM_JOINTS 7
-#define NR_TORSO_JOINTS 3 
 
 IncomingEvent eventFromBottle(const Bottle &b)
 {
@@ -111,7 +110,7 @@ bool vtRFThread::threadInit()
         if (rf->check("rightHand") || rf->check("rightForeArm") ||
            (!rf->check("rightHand") && !rf->check("rightForeArm") && !rf->check("leftHand") && !rf->check("leftForeArm")))
         {
-            for (int i = 0; i < NR_TORSO_JOINTS; i++)
+            for (int i = 0; i < jntsT; i++)
                 armR->releaseLink(i); //torso will be enabled
                         
             Property OptR;
@@ -145,7 +144,7 @@ bool vtRFThread::threadInit()
         if (rf->check("leftHand") || rf->check("leftForeArm") ||
            (!rf->check("rightHand") && !rf->check("rightForeArm") && !rf->check("leftHand") && !rf->check("leftForeArm")))
         {
-            for (int i = 0; i < NR_TORSO_JOINTS; i++)
+            for (int i = 0; i < jntsT; i++)
                 armL->releaseLink(i); //torso will be enabled
             
             Property OptL;
@@ -200,7 +199,7 @@ bool vtRFThread::threadInit()
         }
         iencsT->getAxes(&jntsT);
         encsT = new yarp::sig::Vector(jntsT,0.0);
-        qT.resize(NR_TORSO_JOINTS,0.0); //current values of torso joints (3, in the order expected for iKin: yaw, roll, pitch)
+        qT.resize(jntsT,0.0); //current values of torso joints (3, in the order expected for iKin: yaw, roll, pitch)
 
     /**************************/
         Property OptH;
@@ -838,8 +837,8 @@ bool vtRFThread::trainTaxels(const std::vector<unsigned int> IDv, const int IDx)
 
 bool vtRFThread::readEncodersAndUpdateArmChains()
 {    
-   Vector q1(NR_TORSO_JOINTS+NR_ARM_JOINTS,0.0);
-   Vector q2(NR_TORSO_JOINTS+NR_ARM_JOINTS,0.0);
+   Vector q1(jntsT+NR_ARM_JOINTS,0.0);
+   Vector q2(jntsT+NR_ARM_JOINTS,0.0);
     
    iencsT->getEncoders(encsT->data()); 
    qT[0]=(*encsT)[2]; //reshuffling from motor to iKin order (yaw, roll, pitch)
@@ -852,7 +851,7 @@ bool vtRFThread::readEncodersAndUpdateArmChains()
         iencsR->getEncoders(encsR->data());
         qR=encsR->subVector(0,NR_ARM_JOINTS-1);
         q1.setSubvector(0,qT);
-        q1.setSubvector(NR_TORSO_JOINTS,qR);
+        q1.setSubvector(jntsT,qR);
         armR -> setAng(q1*CTRL_DEG2RAD);
    }    
    if (rf->check("leftHand") || rf->check("leftForeArm") ||
@@ -861,7 +860,7 @@ bool vtRFThread::readEncodersAndUpdateArmChains()
         iencsL->getEncoders(encsL->data());
         qL=encsL->subVector(0,NR_ARM_JOINTS-1);
         q2.setSubvector(0,qT);
-        q2.setSubvector(NR_TORSO_JOINTS,qL);
+        q2.setSubvector(jntsT,qL);
         armL -> setAng(q2*CTRL_DEG2RAD);
    }      
    return true;

--- a/modules/visuoTactileRF/vtRFThread.cpp
+++ b/modules/visuoTactileRF/vtRFThread.cpp
@@ -77,9 +77,8 @@ bool vtRFThread::threadInit()
     ppsEventsPortOut.open(("/"+name+"/pps_events_aggreg:o").c_str());
     dataDumperPortOut.open(("/"+name+"/dataDumper:o").c_str());
 
-    /**
-    * It is not recommended but it is fast practice as well
-    **/
+    
+    //Autoconnection is not recommended; the list below is not uptodate anymore
         // if (robot=="icub")
         // {
         //     Network::connect("/icub/camcalib/left/out",("/"+name+"/imageL:i").c_str());
@@ -90,18 +89,14 @@ bool vtRFThread::threadInit()
         //     Network::connect("/icubSim/cam/left",("/"+name+"/imageL:i").c_str());
         //     Network::connect("/icubSim/cam/right",("/"+name+"/imageR:i").c_str());
         // }
-
         // Network::connect(("/"+name+"/imageL:o").c_str(),"/vtRF/left");
         // Network::connect(("/"+name+"/imageR:o").c_str(),"/vtRF/right");
-
         // Network::connect("/doubleTouch/status:o",("/"+name+"/input:i").c_str());
         // Network::connect("/visuoTactileWrapper/events:o",("/"+name+"/events:i").c_str());
-
         // Network::connect(("/"+name+"/skinGuiForearmL:o").c_str(),"/skinGui/left_forearm_virtual:i");
         // Network::connect(("/"+name+"/skinGuiForearmR:o").c_str(),"/skinGui/right_forearm_virtual:i");
         // Network::connect(("/"+name+"/skinGuiHandL:o").c_str(),"/skinGui/left_hand_virtual:i");
         // Network::connect(("/"+name+"/skinGuiHandR:o").c_str(),"/skinGui/right_hand_virtual:i");
-           
         // Network::connect("/skinManager/skin_events:o",("/"+name+"/skin_events:i").c_str());
         
         ts.update();
@@ -261,15 +256,15 @@ void vtRFThread::run()
 
     dumpedVector.resize(0,0.0);
     printMessage(4,"\n **************************vtRFThread::run() ************************\n");
-    if (stressBottle !=NULL){
+    if (stressBottle !=NULL)
+    {
         stress = stressBottle->get(0).asDouble();
         yAssert((stress>=0.0) && (stress<=1.0));
         yDebug("vtRFThread::run() reading %f stress value from port.\n",stress);
     }
-    else{
+    else
         stress = 0.0;
-    }
-
+    
     // project taxels in World Reference Frame
     for (size_t i = 0; i < iCubSkin.size(); i++)
     {

--- a/modules/visuoTactileRF/vtRFThread.h
+++ b/modules/visuoTactileRF/vtRFThread.h
@@ -107,7 +107,7 @@ protected:
 
     BufferedPort<iCub::skinDynLib::skinContactList> *skinPortIn;  // input from the skinManager
     BufferedPort<yarp::os::Bottle> ppsEventsPortOut;                                             // output for the events
-    Port dataDumperPortOut;                                       // output for the dataDumper (quick thing
+    Port dataDumperPortOut;                                       // output for the dataDumper (quick thing)
     yarp::sig::Vector dumpedVector;
 
     // iCubSkin

--- a/modules/visuoTactileRF/vtRFThread.h
+++ b/modules/visuoTactileRF/vtRFThread.h
@@ -167,11 +167,15 @@ protected:
     IEncoders         *iencsH;
     yarp::sig::Vector *encsH;
     int                jntsH;
-
     // Gaze controller interface
     IGazeControl       *igaze;
     int contextGaze;
 
+    //N.B. All angles in this thread are in degrees
+    yarp::sig::Vector qL; //current values of left arm joints (should be 7)
+    yarp::sig::Vector qR; //current values of right arm joints (should be 7)
+    yarp::sig::Vector qT; //current values of torso joints (3, in the order expected for iKin: yaw, roll, pitch)
+          
     // Stamp for the setEnvelope for the ports
     yarp::os::Stamp ts;
 
@@ -248,6 +252,13 @@ protected:
     **/
     bool getRepresentativeTaxels(const std::vector<unsigned int> IDv, const int IDx, std::vector<unsigned int> &v);
 
+    
+    /**
+    * Will read encoders (torso and arms) and update arm chains.
+    * @return true/false on success failure
+    **/
+    bool readEncodersAndUpdateArmChains();
+    
     /**
     *
     **/

--- a/modules/visuoTactileRF/vtRFThread.h
+++ b/modules/visuoTactileRF/vtRFThread.h
@@ -1,8 +1,7 @@
 /*
  * Copyright (C) 2010 RobotCub Consortium, European Commission FP6 Project IST-004370
- * Author: Alessandro Roncone
- * email:  alessandro.roncone@iit.it
- * website: www.robotcub.org
+ * Author: Alessandro Roncone, Matej Hoffmann
+ * email:  alessandro.roncone@yale.edu, matej.hoffmann@iit.it
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any
  * later version published by the Free Software Foundation.

--- a/modules/visuoTactileRF/vtRFThread.h
+++ b/modules/visuoTactileRF/vtRFThread.h
@@ -153,12 +153,14 @@ protected:
     IEncoders         *iencsR;
     yarp::sig::Vector *encsR;
     iCubArm           *armR;
-    int                jntsR;
+    int                jntsR; //all joints including fingers ~ 16
+    int                jntsAR; //arm joints only ~ 7
     // "Classical" interfaces - LEFT ARM
     IEncoders         *iencsL;
     yarp::sig::Vector *encsL;
     iCubArm           *armL;
-    int                jntsL;
+    int                jntsL; //all joints including fingers ~ 16
+    int                jntsAL; //arm joints only ~ 7
     // "Classical" interfaces - TORSO
     IEncoders         *iencsT;
     yarp::sig::Vector *encsT;

--- a/modules/visuoTactileRF/vtRFThread.h
+++ b/modules/visuoTactileRF/vtRFThread.h
@@ -262,6 +262,13 @@ protected:
     bool readEncodersAndUpdateArmChains();
     
     /**
+    * Will read head encoders and update eye chains.
+    * Assumes that torso encoders have been read before. 
+    * @return true/false on success failure
+    **/
+    bool readHeadEncodersAndUpdateEyeChains();
+        
+    /**
     *
     **/
     bool projectIncomingEvent();


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76314912%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76315208%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76316622%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76317069%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76317131%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76317311%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76317854%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76317921%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76318626%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76319946%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76377610%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76381282%22%2C%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23issuecomment-242679677%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23issuecomment-242679677%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Just%20tested%20everything%20-%20torso%20joints%20are%20taken%20into%20account%20now%20for%20remapping%20to%20taxel%20frames.%20Projections%20of%20taxel%20positions%20to%20camera%20frames%20are%20still%20operational%20too.%22%2C%20%22created_at%22%3A%20%222016-08-26T09%3A32%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6461061%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/matejhof%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20bce409808af6efe31db6f8c03e82b3e9f62fc8a1%20modules/visuoTactileRF/vtRFThread.cpp%20419%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76315208%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22At%20this%20point%2C%20it%20probably%20make%20sense%20to%20update%20also%20the%20%60eyeWrappers%60%20into%20your%20new%20method.%20What%20do%20you%20think%3F%20%5Cr%5Cn%5Cr%5CnI%27m%20talking%20about%20lines%20%601102%3A1115%60%20and%20line%20%601121%60%22%2C%20%22created_at%22%3A%20%222016-08-25T20%3A07%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4378663%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/alecive%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20seems%20so%20-%20this%20one%20is%20also%20called%20repeatedly.%22%2C%20%22created_at%22%3A%20%222016-08-25T20%3A20%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6461061%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/matejhof%22%7D%7D%2C%20%7B%22body%22%3A%20%22Or%2C%20we%20can%20decide%20to%20remove%20%28or%20disable%29%20it%20altogether%20since%20we%20are%20not%20using%20it%20anymore.%22%2C%20%22created_at%22%3A%20%222016-08-25T20%3A21%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4378663%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/alecive%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20I%27m%20not%20using%20it%20most%20of%20the%20time%2C%20but%20can%20be%20useful.%20I%20can%20add%20it%20to%20the%20updateChains%28%29.%20It%20could%20be%20eventually%20made%20optional%20-%20such%20that%20this%20is%20computed%20only%20when%20someone%20is%20interested%20to%20look.%20%22%2C%20%22created_at%22%3A%20%222016-08-25T20%3A25%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6461061%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/matejhof%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-08-25T20%3A25%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4378663%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/alecive%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20addressed%20by%20this%20commit%3A%208a067ce583f2ad65db02468d4d59ba6d340a64c1%20%20%5Cr%5CnJust%20need%20to%20test%20now.%22%2C%20%22created_at%22%3A%20%222016-08-26T08%3A19%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6461061%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/matejhof%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20modules/visuoTactileRF/vtRFThread.cpp%3AL1099-1106%22%7D%2C%20%22Pull%20bce409808af6efe31db6f8c03e82b3e9f62fc8a1%20modules/visuoTactileRF/vtRFThread.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/peripersonal-space/pull/28%23discussion_r76314912%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20it%20really%20needed%20to%20hard%20code%20a%20macro%20for%20the%20number%20of%20torso%20and%20arm%20joints%3F%5Cr%5Cn%5Cr%5CnTorso%20joints%20are%20already%20read%20from%20the%20encoder%20and%20stored%20in%20the%20%60jntsT%60%20variable.%20For%20the%20arm%2C%20you%20cannot%20read%20it%20from%20the%20encoders%2C%20but%20you%20can%20have%20a%20similar%20interface%2C%20i.e.%20a%20%60jntsAL%60%20variable%20that%20you%20initialize%20to%20%607%60%20as%20a%20member%20of%20the%20class%2C%20instead%20of%20a%20%60%23define%60.%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-08-25T20%3A05%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4378663%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/alecive%22%7D%7D%2C%20%7B%22body%22%3A%20%22Matter%20of%20philosophy%20-%20macros%20make%20it%20IMHO%20more%20transparent.%22%2C%20%22created_at%22%3A%20%222016-08-25T20%3A16%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6461061%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/matejhof%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20know%20that%2C%20but%20since%20everything%20else%20is%20handled%20with%20another%20philosophy%2C%20it%27s%20better%20to%20stick%20to%20the%20existing%20one%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-08-25T20%3A19%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4378663%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/alecive%22%7D%7D%2C%20%7B%22body%22%3A%20%22%20I%20prefer%20having%20%60subVector%280%2CNR_ARM_JOINTS%20-1%29%60%20over%20%60subVector%280%2C6%29%60.%20If%20you%20object%20against%20macros%2C%20it%20can%20be%20made%20a%20variable%20with%20the%20same%20name%20%28UPPER_CASE%29%20and%20initialized%20in%20%60init%28%29%60.%20It%27s%20slightly%20more%20work%2C%20but%20is%20the%20same.%20What%20is%20the%20problem%20with%20macro%3F%22%2C%20%22created_at%22%3A%20%222016-08-25T20%3A29%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6461061%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/matejhof%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20problem%20is%20that%20the%20other%20code%20uses%20%60jntsT%60%20%60jntsR%60%2C%20etc%2C%20so%20I%20would%20stick%20with%20that%20%2C%20i.e.%20with%20a%20variable%20%28called%2C%20to%20be%20consistent%2C%20%60jntsAR%60%20%60jntsAL%60%29%2C%20initialized%20in%20the%20init%20as%20you%20said%20%28this%20is%20what%20I%20suggested%20in%20the%20beginning%29.%5Cr%5Cn%5Cr%5Cn%60jntsT%60%20is%20already%20initialized%20and%20used%2C%20so%20you%20can%20use%20that%20for%20the%20torso.%22%2C%20%22created_at%22%3A%20%222016-08-25T20%3A37%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4378663%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/alecive%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20no%20problem.%20%5Cr%5Cn-%20Torso%20joints%20solved%20by%20this%20commit%3A%200fe466a4bef54ef7af3dfdcefaa0dbd3eda512dd%20%5Cr%5Cn-%20%28Sorry%20about%20this%20commit%3A%20%200fe466a4bef54ef7af3dfdcefaa0dbd3eda512dd%20-%20I%20forgot%20to%20pull%20first%2C%20then%20rebase%20somehow%20did%20not%20work%20out%20and%20I%20had%20to%20merge%20manually%20with%20your%20commit%20with%20the%20formatting%20edits%29%5Cr%5Cn-%20Arm%20joints%20solved%20by%20this%20commit%20%2067c7c6f444a068705746f8c50b375c0a79f668c9%20%22%2C%20%22created_at%22%3A%20%222016-08-26T07%3A49%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6461061%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/matejhof%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20modules/visuoTactileRF/vtRFThread.cpp%3AL11-19%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull bce409808af6efe31db6f8c03e82b3e9f62fc8a1 modules/visuoTactileRF/vtRFThread.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/peripersonal-space/pull/28#discussion_r76314912'>File: modules/visuoTactileRF/vtRFThread.cpp:L11-19</a></b>
- <a href='https://github.com/alecive'><img border=0 src='https://avatars.githubusercontent.com/u/4378663?v=3' height=16 width=16'></a> Is it really needed to hard code a macro for the number of torso and arm joints?
Torso joints are already read from the encoder and stored in the `jntsT` variable. For the arm, you cannot read it from the encoders, but you can have a similar interface, i.e. a `jntsAL` variable that you initialize to `7` as a member of the class, instead of a `#define`. :)
- <a href='https://github.com/matejhof'><img border=0 src='https://avatars.githubusercontent.com/u/6461061?v=3' height=16 width=16'></a> Matter of philosophy - macros make it IMHO more transparent.
- <a href='https://github.com/alecive'><img border=0 src='https://avatars.githubusercontent.com/u/4378663?v=3' height=16 width=16'></a> I know that, but since everything else is handled with another philosophy, it's better to stick to the existing one :)
- <a href='https://github.com/matejhof'><img border=0 src='https://avatars.githubusercontent.com/u/6461061?v=3' height=16 width=16'></a> I prefer having `subVector(0,NR_ARM_JOINTS -1)` over `subVector(0,6)`. If you object against macros, it can be made a variable with the same name (UPPER_CASE) and initialized in `init()`. It's slightly more work, but is the same. What is the problem with macro?
- <a href='https://github.com/alecive'><img border=0 src='https://avatars.githubusercontent.com/u/4378663?v=3' height=16 width=16'></a> The problem is that the other code uses `jntsT` `jntsR`, etc, so I would stick with that , i.e. with a variable (called, to be consistent, `jntsAR` `jntsAL`), initialized in the init as you said (this is what I suggested in the beginning).
`jntsT` is already initialized and used, so you can use that for the torso.
- <a href='https://github.com/matejhof'><img border=0 src='https://avatars.githubusercontent.com/u/6461061?v=3' height=16 width=16'></a> Ok, no problem.
- Torso joints solved by this commit: 0fe466a4bef54ef7af3dfdcefaa0dbd3eda512dd
- (Sorry about this commit:  0fe466a4bef54ef7af3dfdcefaa0dbd3eda512dd - I forgot to pull first, then rebase somehow did not work out and I had to merge manually with your commit with the formatting edits)
- Arm joints solved by this commit  67c7c6f444a068705746f8c50b375c0a79f668c9
- [ ] <a href='#crh-comment-Pull bce409808af6efe31db6f8c03e82b3e9f62fc8a1 modules/visuoTactileRF/vtRFThread.cpp 419'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/peripersonal-space/pull/28#discussion_r76315208'>File: modules/visuoTactileRF/vtRFThread.cpp:L1099-1106</a></b>
- <a href='https://github.com/alecive'><img border=0 src='https://avatars.githubusercontent.com/u/4378663?v=3' height=16 width=16'></a> At this point, it probably make sense to update also the `eyeWrappers` into your new method. What do you think?
I'm talking about lines `1102:1115` and line `1121`
- <a href='https://github.com/matejhof'><img border=0 src='https://avatars.githubusercontent.com/u/6461061?v=3' height=16 width=16'></a> It seems so - this one is also called repeatedly.
- <a href='https://github.com/alecive'><img border=0 src='https://avatars.githubusercontent.com/u/4378663?v=3' height=16 width=16'></a> Or, we can decide to remove (or disable) it altogether since we are not using it anymore.
- <a href='https://github.com/matejhof'><img border=0 src='https://avatars.githubusercontent.com/u/6461061?v=3' height=16 width=16'></a> Hmm, I'm not using it most of the time, but can be useful. I can add it to the updateChains(). It could be eventually made optional - such that this is computed only when someone is interested to look.
- <a href='https://github.com/alecive'><img border=0 src='https://avatars.githubusercontent.com/u/4378663?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/matejhof'><img border=0 src='https://avatars.githubusercontent.com/u/6461061?v=3' height=16 width=16'></a> Ok, addressed by this commit: 8a067ce583f2ad65db02468d4d59ba6d340a64c1
Just need to test now.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/peripersonal-space/pull/28#issuecomment-242679677'>General Comment</a></b>
- <a href='https://github.com/matejhof'><img border=0 src='https://avatars.githubusercontent.com/u/6461061?v=3' height=16 width=16'></a> Just tested everything - torso joints are taken into account now for remapping to taxel frames. Projections of taxel positions to camera frames are still operational too.


<a href='https://www.codereviewhub.com/robotology/peripersonal-space/pull/28?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/peripersonal-space/pull/28?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/peripersonal-space/pull/28'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>